### PR TITLE
fix(relay): fix relayed event "removed"

### DIFF
--- a/src/relay.js
+++ b/src/relay.js
@@ -3,7 +3,7 @@ import {pull} from 'lodash';
 
 const ucfirst = str => str.charAt(0).toUpperCase() + str.substr(1);
 
-const RELAYED_EVENTS = ['created', /updated:?.*/, 'deleted'];
+const RELAYED_EVENTS = ['created', /updated:?.*/, 'removed'];
 
 // @TODO
 // test publish on one model do not impact other model!


### PR DESCRIPTION
I fixed a typo in RELAYED_EVENTS variable.

In `index.js` file, the event dispatched is **removed**, but in `relay.js` it's  **deleted** event which is expected.