### PR TITLE
feat(hook): update remove hook for mongoose@^5

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@
 
 React on database changes with document and models events
 
+## Note
+
+- **v2.x** for `mongoose@^5`
+- **v1.x** for `mongoose@^4`
+
 ## Quickstart
 
 - Load the plugin inside your schema

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-plugin-events",
-  "version": "1.4.2",
+  "version": "2.0.0",
   "description": "",
   "main": "lib/index.js",
   "scripts": {
@@ -26,7 +26,7 @@
     "mongodb-extjson": "^3.0.3"
   },
   "peerDependencies": {
-    "mongoose": ">= 4"
+    "mongoose": ">= 5"
   },
   "optionalDependencies": {},
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -137,11 +137,16 @@ export default function eventsPlugin(schema, {ignoredPaths = ['updatedAt', 'crea
   schema.post('update', postUpdate);
   schema.post('findOneAndUpdate', postUpdate);
 
-  schema.post('remove', function postRemove() {
+  schema.post('remove', {query: true}, function postRemove() {
     const doc = this;
-    const model = doc.model(doc.constructor.modelName);
-    const object = doc.toObject();
-    model.$emit('removed', object);
+    // Check if it's a single doc or multi docs which have been removed
+    if (doc.toObject) {
+      const model = doc.model(doc.constructor.modelName);
+      model.$emit('removed', {query: doc.toObject()});
+    } else {
+      const query = doc.getQuery();
+      doc.model.$emit('removed', {query});
+    }
   });
 
   // Prepare potential relays


### PR DESCRIPTION
Update remove hook in order to support a new feature from __mongoose@^5__. 
Now it's possible to catch remove event when it's called from `Model.remove`. In __mongoose@^4__ we were only able to catch `doc.remove`

Please find more info on Mongoose API from this link.

[https://mongoosejs.com/docs/middleware.html#naming](url)